### PR TITLE
fix: java memory size lowered by 24MB

### DIFF
--- a/cms/grading/languages/java_jdk.py
+++ b/cms/grading/languages/java_jdk.py
@@ -90,12 +90,13 @@ class JavaJDK(Language):
         if JavaJDK.USE_JAR:
             # executable_filename is a jar file, main is the name of
             # the main java class
-            return [["/usr/bin/java", "-Deval=true", "-Xmx1024M", "-Xss1024M",
+	    # Suggested by Martin to be lowered by 24MB given problem limit of 1024MB
+            return [["/usr/bin/java", "-Deval=true", "-Xmx1000M", "-Xss1000M",
                      "-Xbatch", "-XX:+UseSerialGC", "-XX:-TieredCompilation",
 	                     "-XX:CICompilerCount=1", "-cp", executable_filename, main] + args]
         else:
             unzip_command = ["/usr/bin/unzip", executable_filename]
-            command = ["/usr/bin/java", "-Deval=true", "-Xmx1024M", "-Xss1024M",
+            command = ["/usr/bin/java", "-Deval=true", "-Xmx1000M", "-Xss1000M",
                        "-Xbatch", "-XX:+UseSerialGC", "-XX:-TieredCompilation",
 	                       "-XX:CICompilerCount=1", main] + args
             return [unzip_command, command]


### PR DESCRIPTION
Suggested by Martin to guard us against cases where JVM could possibly crash